### PR TITLE
Add github actions workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,15 +6,52 @@ on:
     branches:
       - "**"
 
+env:
+  # push images to the github container registry
+  REGISTRY: ghrc.io
+  # store images in the datadog/catadog repository
+  REPO: datadog/catadog
+
 jobs:
   build:
+    strategy:
+      # in matrix strategy where you're running multiple jobs with different variable combinations, setting fail-fast to false lets jobs continue running despite other failed jobs
+      fail-fast: false
+      # not sure if we need a matrix strategy to test multiple different versions of ruby... catadog's base image is ruby 3.4 so maybe we should only have ruby 3.4?
+      matrix:
+        include:
+          - engine: ruby
+            version: "3.4"
     runs-on: ubuntu-latest
+    name: build (${{ matrix.engine }} ${{ matrix.version }})
     steps:
+      - name: set variables
+        id: vars
+        run: |
+          echo "SRC=." >> $GITHUB_OUTPUT
+          echo "IMAGE=${{ env.REGISTRY }}/${{ env.REPO }}/engines/${{ matrix.engine }}" >> $GITHUB_OUTPUT
+          echo "TAG=${{ matrix.version }}" >> $GITHUB_OUTPUT
+          echo "DOCKERFILE=./Dockerfile" >> $GITHUB_OUTPUT
+      # check out repository code
       - name: checkout
         uses: actions/checkout@v4
-      - name: build image
-        run: docker buildx build -t catadog .
-      - name: test image by starting up a container
-        run: docker run --rm -d --name catadog catadog
-      - name: kill container
-        run: docker container kill catadog
+      # docker container engine enables advanced buildx features, possibly to allow different platforms (x86_64 and aarch64-linux)
+      - name: set up docker container engine
+        run: |
+          docker buildx create --name=container --driver=docker-container --use --bootstrap
+      # build x86_64 image
+      - name: build single-arch image (x86_64)
+        run: |
+          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=false --platform linux/x86_64 -f ${{ steps.vars.outputs.DOCKERFILE }}
+      # tag image so that it can be referenced in testing step. tag separately from build to avoid interference w caching
+      - name: tag single-arch image (x86_64)
+        run: |
+          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --load --platform linux/x86_64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
+      # test image 
+      - name: test single-arch image (x86_64)
+        run: |
+          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'true'
+          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} ruby -e 'puts RUBY_DESCRIPTION'
+          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} gem --version
+          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
+          docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,29 +12,11 @@ on:
     branches:
       - "**"
 
-env:
-  REGISTRY: ghrc.io
-  REPO: datadog/catadog
-
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      # Test only ruby 3.4
-      matrix:
-        include:
-          - engine: ruby
-            version: "3.4"
     runs-on: ubuntu-latest
-    name: Build (${{ matrix.engine }} ${{ matrix.version }})
+    name: Build ruby 3.4
     steps:
-      - name: Set variables
-        id: vars
-        run: |
-          echo "SRC=." >> $GITHUB_OUTPUT
-          echo "IMAGE=${{ env.REGISTRY }}/${{ env.REPO }}/engines/${{ matrix.engine }}" >> $GITHUB_OUTPUT
-          echo "TAG=${{ matrix.version }}" >> $GITHUB_OUTPUT
-          echo "DOCKERFILE=./Dockerfile" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -48,17 +30,17 @@ jobs:
       # Tag image separately to avoid interference with caching and so that testing step can reference the image
       - name: Build single-arch image (x86-64)
         run: |
-          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=false --platform linux/x86_64 -f ${{ steps.vars.outputs.DOCKERFILE }}
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --output=type=image,push=false --platform linux/x86_64 -f ./Dockerfile
       - name: Tag single-arch image (x86-64)
         run: |
-          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --load --platform linux/x86_64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --load --platform linux/x86_64 -f ./Dockerfile --tag ghrc.io/datadog/catadog
       - name: Test single-arch image (x86-64)
         run: |
-          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'true'
-          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} ruby -e 'puts RUBY_DESCRIPTION'
-          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} gem --version
-          docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
-          docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'
+          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog /bin/sh -c 'true'
+          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog ruby -e 'puts RUBY_DESCRIPTION'
+          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog gem --version
+          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog bundle --version
+          docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ghrc.io/datadog/catadog /bin/sh -c 'bundle install && bundle exec rake test'
 
       # Build image for aarch64-linux, emulated under qemu
       # 
@@ -68,17 +50,17 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install arm64
       - name: Build single-arch image (aarch64-linux)
         run: |
-          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=false --platform linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }}
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --output=type=image,push=false --platform linux/aarch64 -f ./Dockerfile
       - name: Tag single-arch image (aarch64-linux)
         run: |
-          docker buildx build ${{ steps.vars.outputs.SRC }}  --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --load --platform linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
+          docker buildx build .  --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --load --platform linux/aarch64 -f ./Dockerfile --tag ghrc.io/datadog/catadog
       - name: Test single-arch image (aarch64-linux)
         run: |
-          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'true'
-          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} ruby -e 'puts RUBY_DESCRIPTION'
-          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} gem --version
-          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
-          docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'
+          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog /bin/sh -c 'true'
+          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog ruby -e 'puts RUBY_DESCRIPTION'
+          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog gem --version
+          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog bundle --version
+          docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ghrc.io/datadog/catadog /bin/sh -c 'bundle install && bundle exec rake test'
       
       # Assemble multi-arch image for a combined push to the registry
       # 
@@ -86,8 +68,8 @@ jobs:
       - name: Log in to the container registry
         if: ${{ inputs.push }}
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghrc.io -u ${{ github.actor }} --password-stdin
       - name: Build multi-arch image (x86-64, aarch64)
         if: ${{ inputs.push }}
         run: |
-          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=true --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/x86_64,linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --output=type=image,push=true --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/x86_64,linux/aarch64 -f ./Dockerfile --tag ghrc.io/datadog/catadog

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,13 @@
 name: Build Catadog
 
 on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: Push images
+        required: true
+        type: boolean
+        default: true
   push: 
     branches:
       - "**"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,20 @@
+name: build catadog
+
+on:
+  # trigger catadog every time a push occurs on any branch
+  push: 
+    branches:
+      - "**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: build image
+        run: docker buildx build -t catadog .
+      - name: test image by starting up a container
+        run: docker run --rm -d --name catadog catadog
+      - name: kill container
+        run: docker container kill catadog

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,54 +1,51 @@
-name: build catadog
+name: Build Catadog
 
 on:
-  # trigger catadog every time a push occurs on any branch
   push: 
     branches:
       - "**"
 
 env:
-  # push images to the github container registry
   REGISTRY: ghrc.io
-  # store images in the datadog/catadog repository
   REPO: datadog/catadog
 
 jobs:
   build:
     strategy:
-      # in matrix strategy where you're running multiple jobs with different variable combinations, setting fail-fast to false lets jobs continue running despite other failed jobs
       fail-fast: false
-      # not sure if we need a matrix strategy to test multiple different versions of ruby... catadog's base image is ruby 3.4 so maybe we should only have ruby 3.4?
+      # Test only ruby 3.4
       matrix:
         include:
           - engine: ruby
             version: "3.4"
     runs-on: ubuntu-latest
-    name: build (${{ matrix.engine }} ${{ matrix.version }})
+    name: Build (${{ matrix.engine }} ${{ matrix.version }})
     steps:
-      - name: set variables
+      - name: Set variables
         id: vars
         run: |
           echo "SRC=." >> $GITHUB_OUTPUT
           echo "IMAGE=${{ env.REGISTRY }}/${{ env.REPO }}/engines/${{ matrix.engine }}" >> $GITHUB_OUTPUT
           echo "TAG=${{ matrix.version }}" >> $GITHUB_OUTPUT
           echo "DOCKERFILE=./Dockerfile" >> $GITHUB_OUTPUT
-      # check out repository code
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      # docker container engine enables advanced buildx features, possibly to allow different platforms (x86_64 and aarch64-linux)
-      - name: set up docker container engine
+
+      # Use docker-container engine to enable advanced buildx features
+      - name: Set up docker container engine
         run: |
           docker buildx create --name=container --driver=docker-container --use --bootstrap
-      # build x86_64 image
-      - name: build single-arch image (x86_64)
+
+      # Build image for x86-64
+      # 
+      # Tag image separately to avoid interference with caching and so that testing step can reference the image
+      - name: Build single-arch image (x86-64)
         run: |
           docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=false --platform linux/x86_64 -f ${{ steps.vars.outputs.DOCKERFILE }}
-      # tag image so that it can be referenced in testing step. tag separately from build to avoid interference w caching
-      - name: tag single-arch image (x86_64)
+      - name: Tag single-arch image (x86-64)
         run: |
           docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --load --platform linux/x86_64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
-      # test image 
-      - name: test single-arch image (x86_64)
+      - name: Test single-arch image (x86-64)
         run: |
           docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'true'
           docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} ruby -e 'puts RUBY_DESCRIPTION'
@@ -56,17 +53,19 @@ jobs:
           docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
           docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'
 
-      # now build image for aarch64-linux, emulated under qemu
-      - name: enable aarch64 emulation (x86_64)
+      # Build image for aarch64-linux, emulated under qemu
+      # 
+      # Tag image separately to avoid interference with caching and so that testing step can reference the image
+      - name: Enable aarch64 emulation (x86-64)
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64
-      - name: build single-arch image (aarch64-linux)
+      - name: Build single-arch image (aarch64-linux)
         run: |
           docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=false --platform linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }}
-      - name: tag single-arch image (aarch64-linux)
+      - name: Tag single-arch image (aarch64-linux)
         run: |
           docker buildx build ${{ steps.vars.outputs.SRC }}  --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --load --platform linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
-      - name: test single-arch image (aarch64-linux)
+      - name: Test single-arch image (aarch64-linux)
         run: |
           docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'true'
           docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} ruby -e 'puts RUBY_DESCRIPTION'
@@ -74,12 +73,14 @@ jobs:
           docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
           docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'
       
-      # finally assemble multi-arch image for a combined push to the registry. this reruns docker build but because the layers are cached, it's fast
-      - name: log in to the container registry
+      # Assemble multi-arch image for a combined push to the registry
+      # 
+      # Docker build is rerun, but build is fast because the layers are already cached
+      - name: Log in to the container registry
         if: ${{ inputs.push }}
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-      - name: Build multi-arch image (x86_64, aarch64)
+      - name: Build multi-arch image (x86-64, aarch64)
         if: ${{ inputs.push }}
         run: |
           docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=true --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/x86_64,linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build ruby 3.4
+    name: Build Docker image
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,17 +33,17 @@ jobs:
       # Tag image separately to avoid interference with caching and so that testing step can reference the image
       - name: Build single-arch image (x86-64)
         run: |
-          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --output=type=image,push=false --platform linux/x86_64 -f ./Dockerfile
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghcr.io/datadog/catadog --output=type=image,push=false --platform linux/x86_64 -f ./Dockerfile
       - name: Tag single-arch image (x86-64)
         run: |
-          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --load --platform linux/x86_64 -f ./Dockerfile --tag ghrc.io/datadog/catadog
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghcr.io/datadog/catadog --load --platform linux/x86_64 -f ./Dockerfile --tag ghcr.io/datadog/catadog
       - name: Test single-arch image (x86-64)
         run: |
-          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog /bin/sh -c 'true'
-          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog ruby -e 'puts RUBY_DESCRIPTION'
-          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog gem --version
-          docker run --platform linux/x86_64 --rm ghrc.io/datadog/catadog bundle --version
-          docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ghrc.io/datadog/catadog /bin/sh -c 'bundle install && bundle exec rake test'
+          docker run --platform linux/x86_64 --rm ghcr.io/datadog/catadog /bin/sh -c 'true'
+          docker run --platform linux/x86_64 --rm ghcr.io/datadog/catadog ruby -e 'puts RUBY_DESCRIPTION'
+          docker run --platform linux/x86_64 --rm ghcr.io/datadog/catadog gem --version
+          docker run --platform linux/x86_64 --rm ghcr.io/datadog/catadog bundle --version
+          docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ghcr.io/datadog/catadog /bin/sh -c 'bundle install && bundle exec rake test'
 
       # Build image for aarch64-linux, emulated under qemu
       # 
@@ -50,17 +53,17 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install arm64
       - name: Build single-arch image (aarch64-linux)
         run: |
-          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --output=type=image,push=false --platform linux/aarch64 -f ./Dockerfile
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghcr.io/datadog/catadog --output=type=image,push=false --platform linux/aarch64 -f ./Dockerfile
       - name: Tag single-arch image (aarch64-linux)
         run: |
-          docker buildx build .  --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --load --platform linux/aarch64 -f ./Dockerfile --tag ghrc.io/datadog/catadog
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghcr.io/datadog/catadog --load --platform linux/aarch64 -f ./Dockerfile --tag ghcr.io/datadog/catadog
       - name: Test single-arch image (aarch64-linux)
         run: |
-          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog /bin/sh -c 'true'
-          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog ruby -e 'puts RUBY_DESCRIPTION'
-          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog gem --version
-          docker run --platform linux/aarch64 --rm ghrc.io/datadog/catadog bundle --version
-          docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ghrc.io/datadog/catadog /bin/sh -c 'bundle install && bundle exec rake test'
+          docker run --platform linux/aarch64 --rm ghcr.io/datadog/catadog /bin/sh -c 'true'
+          docker run --platform linux/aarch64 --rm ghcr.io/datadog/catadog ruby -e 'puts RUBY_DESCRIPTION'
+          docker run --platform linux/aarch64 --rm ghcr.io/datadog/catadog gem --version
+          docker run --platform linux/aarch64 --rm ghcr.io/datadog/catadog bundle --version
+          docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ghcr.io/datadog/catadog /bin/sh -c 'bundle install && bundle exec rake test'
       
       # Assemble multi-arch image for a combined push to the registry
       # 
@@ -68,8 +71,8 @@ jobs:
       - name: Log in to the container registry
         if: ${{ inputs.push }}
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghrc.io -u ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build multi-arch image (x86-64, aarch64)
         if: ${{ inputs.push }}
         run: |
-          docker buildx build . --builder=container --cache-from=type=registry,ref=ghrc.io/datadog/catadog --output=type=image,push=true --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/x86_64,linux/aarch64 -f ./Dockerfile --tag ghrc.io/datadog/catadog
+          docker buildx build . --builder=container --cache-from=type=registry,ref=ghcr.io/datadog/catadog --output=type=image,push=true --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/x86_64,linux/aarch64 -f ./Dockerfile --tag ghcr.io/datadog/catadog

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,3 +73,13 @@ jobs:
           docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} gem --version
           docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
           docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'
+      
+      # finally assemble multi-arch image for a combined push to the registry. this reruns docker build but because the layers are cached, it's fast
+      - name: log in to the container registry
+        if: ${{ inputs.push }}
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - name: Build multi-arch image (x86_64, aarch64)
+        if: ${{ inputs.push }}
+        run: |
+          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=true --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/x86_64,linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,3 +55,21 @@ jobs:
           docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} gem --version
           docker run --platform linux/x86_64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
           docker run --platform linux/x86_64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'
+
+      # now build image for aarch64-linux, emulated under qemu
+      - name: enable aarch64 emulation (x86_64)
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64
+      - name: build single-arch image (aarch64-linux)
+        run: |
+          docker buildx build ${{ steps.vars.outputs.SRC }} --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --output=type=image,push=false --platform linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }}
+      - name: tag single-arch image (aarch64-linux)
+        run: |
+          docker buildx build ${{ steps.vars.outputs.SRC }}  --builder=container --cache-from=type=registry,ref=${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} --load --platform linux/aarch64 -f ${{ steps.vars.outputs.DOCKERFILE }} --tag ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }}
+      - name: test single-arch image (aarch64-linux)
+        run: |
+          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'true'
+          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} ruby -e 'puts RUBY_DESCRIPTION'
+          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} gem --version
+          docker run --platform linux/aarch64 --rm ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} bundle --version
+          docker run --platform linux/aarch64 --rm -v "${PWD}":"${PWD}" -w "${PWD}" ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.TAG }} /bin/sh -c 'bundle install && bundle exec rake test'

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ end
 group :dev do
   gem "pry"
 end
+
+gem "ostruct", "~> 0.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,21 +11,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.4)
+    activesupport (7.2.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     coderay (1.1.3)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     csv (3.3.0)
     drb (2.2.1)
@@ -41,7 +42,7 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     ffi (1.17.0-x86_64-linux-musl)
     fileutils (1.7.2)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
@@ -49,15 +50,15 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.0)
+    logger (1.6.1)
     method_source (1.1.0)
-    minitest (5.24.1)
+    minitest (5.25.1)
     msgpack (1.7.2)
-    mustermann (3.0.1)
+    mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    mutex_m (0.2.0)
-    parallel (1.25.1)
-    parser (3.3.4.1)
+    ostruct (0.6.0)
+    parallel (1.26.3)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
     pry (0.14.2)
@@ -73,11 +74,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.5.2)
+    rbs (3.5.3)
       logger
     regexp_parser (2.9.2)
-    rexml (3.3.4)
-      strscan
+    rexml (3.3.7)
     rubocop (1.52.1)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -88,7 +88,7 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.0)
+    rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
     rubocop-performance (1.18.0)
       rubocop (>= 1.7.0, < 2.0)
@@ -134,7 +134,7 @@ GEM
     tilt (2.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
     webrick (1.8.1)
 
 PLATFORMS
@@ -152,6 +152,7 @@ PLATFORMS
 
 DEPENDENCIES
   catadog!
+  ostruct (~> 0.6.0)
   pry
   rake (~> 13.0)
   rbs

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -1,5 +1,7 @@
 if ARGV.empty? || ARGV == %W[bundle exec catadog]
   exec "bundle exec catadog -h 0.0.0.0"
-else
+elsif ARGV[0].start_with?("-")
   exec "bundle exec catadog -h 0.0.0.0 #{ARGV.join(" ")}"
+else
+  exec ARGV.join(" ").to_s
 end


### PR DESCRIPTION
This PR creates a GitHub Actions workflow that builds the `catadog` Docker image in CI for both x86-64 and aarch64-linux architectures. The workflow builds specifically for `ruby 3.4`, and the pushed image is located at [ghcr.io/datadog/catadog:latest](https://github.com/datadog/catadog/pkgs/container/catadog). The image currently has no tag, and it is only pushed when manually dispatched. NOTE that though the workflow is technically running the test suite, as of this PR **there are no catadog tests** in this test suite.

After merging, there is also suspected [flakiness](https://github.com/DataDog/catadog/actions/runs/11077713447/job/30783581819) in Github Actions: [401 unauthorization error](https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1) when pulling image from docker.io.